### PR TITLE
[BE-#41] 테스트시 8080포트 사용중이라 안되는 오류 수정

### DIFF
--- a/BE/src/test/resources/application.properties
+++ b/BE/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=30279


### PR DESCRIPTION
Fixes #41 

## 설명

젠킨스가 8080포트를 이미 사용중이어서, main method 테스트시에 실패하여 수정합니다.

## 작업 유형

- [x] 버그 수정

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

