### PR TITLE
[BE-#71] Issue 상세조회 API 개발

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import kr.codesquad.issuetracker.controller.request.IssueCreateRequest;
 import kr.codesquad.issuetracker.controller.request.IssuesOpenStatusChangeRequest;
+import kr.codesquad.issuetracker.controller.response.IssueDetail;
 import kr.codesquad.issuetracker.controller.response.IssueResponse;
 import kr.codesquad.issuetracker.controller.response.JobResponse;
 import kr.codesquad.issuetracker.controller.response.SearchFilterLabelResponse;
@@ -18,6 +19,7 @@ import kr.codesquad.issuetracker.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,6 +49,13 @@ public class IssueController {
     log.debug("이슈 목록 반환 객체: {}", issueResponse);
 
     return issueResponse;
+  }
+
+  @GetMapping("/{issueNumber}")
+  public IssueDetail showIssueDetail(@PathVariable Long issueNumber) {
+    log.debug("상세 정보를 보기 원하는 issue의 번호: {}", issueNumber);
+
+    return issueService.findIssueDetail(issueNumber);
   }
 
   @PostMapping

--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/response/IssueDetail.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/response/IssueDetail.java
@@ -1,0 +1,55 @@
+package kr.codesquad.issuetracker.controller.response;
+
+import static java.util.stream.Collectors.toList;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.codesquad.issuetracker.domain.comment.CommentOfIssue;
+import kr.codesquad.issuetracker.domain.issue.Issue;
+import kr.codesquad.issuetracker.domain.label.LabelOfIssue;
+import kr.codesquad.issuetracker.domain.milestone.MilestoneOfIssue;
+import kr.codesquad.issuetracker.domain.relation.IssueAssignee;
+import kr.codesquad.issuetracker.domain.relation.IssueLabel;
+import kr.codesquad.issuetracker.domain.user.UserOfIssue;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueDetail {
+
+  private Long issueNumber;
+  private boolean isOpened;
+  private String title;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private UserOfIssue author;
+  private List<UserOfIssue> assignees;
+  private List<LabelOfIssue> labels;
+  private MilestoneOfIssue milestone;
+  private List<CommentOfIssue> comments;
+
+  public IssueDetail(Issue issue) {
+    this.issueNumber = issue.getIssueNumber();
+    this.isOpened = issue.isOpened();
+    this.title = issue.getTitle();
+    this.createdAt = issue.getCreatedAt();
+    this.updatedAt = issue.getUpdatedAt();
+    this.author = new UserOfIssue(issue.getAuthor());
+    this.assignees = issue.getAssignees().stream()
+        .map(IssueAssignee::getAssignee)
+        .map(UserOfIssue::new)
+        .collect(toList());
+    this.labels = issue.getLabels().stream()
+        .map(IssueLabel::getLabel)
+        .map(LabelOfIssue::new)
+        .collect(toList());
+    this.milestone = new MilestoneOfIssue(issue.getMilestone());
+    this.comments = issue.getComments().stream().map(CommentOfIssue::new).collect(toList());
+  }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/comment/Comment.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/comment/Comment.java
@@ -50,7 +50,6 @@ public class Comment {
   private Issue issue;
 
   @Builder
-
   public Comment(Long id, String description, LocalDateTime createdAt, LocalDateTime updatedAt,
       List<Image> images, User writer, Issue issue) {
     this.id = id;

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/comment/CommentOfIssue.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/comment/CommentOfIssue.java
@@ -1,0 +1,33 @@
+package kr.codesquad.issuetracker.domain.comment;
+
+import static java.util.stream.Collectors.toList;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.codesquad.issuetracker.domain.user.UserOfIssue;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentOfIssue {
+
+  private String description;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private List<ImageOfComment> images;
+  private UserOfIssue writer;
+
+  public CommentOfIssue(Comment comment) {
+    this.description = comment.getDescription();
+    this.createdAt = comment.getCreatedAt();
+    this.updatedAt = comment.getUpdatedAt();
+    this.images = comment.getImages().stream().map(ImageOfComment::new).collect(toList());
+    this.writer = new UserOfIssue(comment.getWriter());
+  }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/comment/ImageOfComment.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/comment/ImageOfComment.java
@@ -1,0 +1,20 @@
+package kr.codesquad.issuetracker.domain.comment;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageOfComment {
+
+  private String url;
+
+  public ImageOfComment(Image image) {
+    this.url = image.getUrl();
+  }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
@@ -9,6 +9,7 @@ import kr.codesquad.issuetracker.common.error.exception.domain.milestone.Milesto
 import kr.codesquad.issuetracker.controller.request.IssueCreateRequest;
 import kr.codesquad.issuetracker.controller.request.IssueOpenState;
 import kr.codesquad.issuetracker.controller.request.IssuesOpenStatusChangeRequest;
+import kr.codesquad.issuetracker.controller.response.IssueDetail;
 import kr.codesquad.issuetracker.domain.comment.Comment;
 import kr.codesquad.issuetracker.domain.issue.Issue;
 import kr.codesquad.issuetracker.domain.issue.IssueOfIssueList;
@@ -98,5 +99,10 @@ public class IssueService {
         .build());
 
     return newIssue.getIssueNumber() != null;
+  }
+
+  @Transactional(readOnly = true)
+  public IssueDetail findIssueDetail(Long issueNumber) {
+    return new IssueDetail(issueRepository.find(issueNumber));
   }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
@@ -38,7 +38,10 @@ public class IssueService {
 
   @Transactional(readOnly = true)
   public List<IssueOfIssueList> findOpenedIssues() {
-    return issueRepository.findOpenedIssues().stream().map(IssueOfIssueList::new).collect(toList());
+    return issueRepository.findOpenedIssues().stream()
+        .map(IssueOfIssueList::new)
+        .sorted(((o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt())))
+        .collect(toList());
   }
 
   public boolean updateIssuesOpenStatus(IssuesOpenStatusChangeRequest statusChangeRequest) {


### PR DESCRIPTION
Fixes #71

## 설명

Issue 상세조회 API를 개발합니다.
이슈 목록이 역순정렬으로 출력되지 않아서 역순정렬을 하도록 하였습니다.

## 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 관련 문서 업데이트 필요

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

