### PR TITLE
[BE-#96] Auth 인터셉터 추가 및 하드코딩으로 유저정보 넣는 부분 모두 변경

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker/common/config/WebConfig.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/common/config/WebConfig.java
@@ -4,25 +4,24 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.List;
 import kr.codesquad.issuetracker.common.security.GithubKey;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-  @Value("${GITHUB_CLIENT_ID}")
-  private String githubClientId;
-
-  @Value("${GITHUB_CLIENT_SECRET}")
-  private String githubClientSecret;
+  private final HandlerInterceptor interceptor;
 
   @Bean
   public GithubKey githubKey() {
-    return new GithubKey(githubClientId, githubClientSecret);
+    return new GithubKey(System.getenv("GITHUB_CLIENT_ID"), System.getenv("GITHUB_CLIENT_SECRET"));
   }
 
   @Override
@@ -33,5 +32,17 @@ public class WebConfig implements WebMvcConfigurer {
         .ifPresent(
             converter ->
                 ((MappingJackson2HttpMessageConverter) converter).setDefaultCharset(UTF_8));
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(interceptor)
+        .addPathPatterns("/**")
+        .excludePathPatterns(
+            "/login/**",
+            "/v2/api-docs",
+            "/swagger-resources/**",
+            "/swagger-ui.html",
+            "/webjars/**");
   }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/common/interceptor/AuthInterceptor.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/common/interceptor/AuthInterceptor.java
@@ -1,0 +1,39 @@
+package kr.codesquad.issuetracker.common.interceptor;
+
+import java.util.Optional;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import kr.codesquad.issuetracker.common.error.exception.LoginRequiredException;
+import kr.codesquad.issuetracker.domain.user.UserDTO;
+import kr.codesquad.issuetracker.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.WebUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+  private final JwtService jwtService;
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) {
+    if (request.getMethod().equals("OPTIONS")) {
+      log.info("options 메서드는 통과");
+      return true;
+    }
+
+    Optional<Cookie> jwtCookie = Optional.ofNullable(WebUtils.getCookie(request, "jwt"));
+    UserDTO user = jwtService
+        .getUserFromJws(jwtCookie.orElseThrow(LoginRequiredException::new).getValue());
+    request.setAttribute("user", user);
+    log.debug("user: {}", user);
+    log.debug("cookie: {}", jwtCookie);
+    return true;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
@@ -117,7 +117,7 @@ public class IssueController {
   }
 
   @PutMapping("/{issueNumber}/comments/{commentOrder}")
-  public JobResponse createComment(@PathVariable Long issueNumber,
+  public JobResponse updateComment(@PathVariable Long issueNumber,
       @PathVariable int commentOrder,
       @RequestBody CommentRequest commentRequest) {
     log.debug("Comment를 변경하려는 issueNumber: {}, comment id: {}, Comment 추가 정보: {}", issueNumber,

--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
@@ -3,6 +3,7 @@ package kr.codesquad.issuetracker.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import kr.codesquad.issuetracker.controller.request.CommentRequest;
 import kr.codesquad.issuetracker.controller.request.IssueCreateRequest;
 import kr.codesquad.issuetracker.controller.request.IssueUpdateRequest;
@@ -14,6 +15,7 @@ import kr.codesquad.issuetracker.controller.response.SearchFilterLabelResponse;
 import kr.codesquad.issuetracker.controller.response.SearchFilterMilestoneResponse;
 import kr.codesquad.issuetracker.controller.response.SearchFilterUserResponse;
 import kr.codesquad.issuetracker.domain.issue.IssueOfIssueList;
+import kr.codesquad.issuetracker.domain.user.UserDTO;
 import kr.codesquad.issuetracker.service.IssueService;
 import kr.codesquad.issuetracker.service.LabelService;
 import kr.codesquad.issuetracker.service.MilestoneService;
@@ -61,10 +63,13 @@ public class IssueController {
   }
 
   @PostMapping("")
-  public JobResponse createIssue(@RequestBody IssueCreateRequest issueCreateRequest) {
+  public JobResponse createIssue(@RequestBody IssueCreateRequest issueCreateRequest,
+      HttpServletRequest request
+  ) {
     log.debug("요청 객체: {}", issueCreateRequest);
+    Long id = Long.parseLong(((UserDTO) request.getAttribute("user")).getId());
 
-    return JobResponse.of(issueService.createIssue(issueCreateRequest));
+    return JobResponse.of(issueService.createIssue(issueCreateRequest, id));
   }
 
   @PutMapping("{issueNumber}")
@@ -110,10 +115,11 @@ public class IssueController {
 
   @PostMapping("/{issueNumber}/comments")
   public JobResponse createComment(@PathVariable Long issueNumber,
-      @RequestBody CommentRequest commentRequest) {
+      @RequestBody CommentRequest commentRequest, HttpServletRequest request) {
     log.debug("Comment를 추가하려는 issueNumber: {}, Comment 추가 정보: {}", issueNumber, commentRequest);
+    Long id = Long.parseLong(((UserDTO) request.getAttribute("user")).getId());
 
-    return JobResponse.of(issueService.createComment(issueNumber, commentRequest));
+    return JobResponse.of(issueService.createComment(issueNumber, commentRequest, id));
   }
 
   @PutMapping("/{issueNumber}/comments/{commentOrder}")

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/user/User.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/user/User.java
@@ -56,4 +56,8 @@ public class User {
     this.githubToken = githubToken;
     this.profileImage = profileImage;
   }
+
+  public void changeGithubToken(String githubToken) {
+    this.githubToken = githubToken;
+  }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/user/UserDTO.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/user/UserDTO.java
@@ -8,23 +8,29 @@ import lombok.ToString;
 @ToString
 public class UserDTO {
 
+  private final String id;
+  private final String userId;
   private final String nickname;
   private final String email;
 
-  private UserDTO(String nickname, String email) {
+  private UserDTO(String id, String userId, String nickname, String email) {
+    this.id = id;
+    this.userId = userId;
     this.nickname = nickname;
     this.email = email;
   }
 
-  public static UserDTO of(String nickname, String email) {
-    return new UserDTO(nickname, email);
+  public static UserDTO of(String id, String userId, String nickname, String email) {
+    return new UserDTO(id, userId, nickname, email);
   }
 
   public static UserDTO of(Map<String, String> userMap) {
-    return new UserDTO(userMap.get("nickname"), userMap.get("email"));
+    return new UserDTO(userMap.get("id"), userMap.get("userId"), userMap.get("nickname"),
+        userMap.get("email"));
   }
 
   public static UserDTO of(User user) {
-    return new UserDTO(user.getNickname(), user.getEmail());
+    return new UserDTO(user.getId().toString(), user.getUserId(), user.getNickname(),
+        user.getEmail());
   }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
@@ -61,16 +61,16 @@ public class IssueService {
     return issueNumbers.equals(updatedIssueNumbers);
   }
 
-  public boolean createIssue(IssueCreateRequest issueCreateRequest) {
+  public boolean createIssue(IssueCreateRequest issueCreateRequest, Long id) {
     LocalDateTime now = LocalDateTime.now();
-    User author = userRepository.find(1L); // TODO: 유저정보 토큰에서 파싱해오기
+    User author = userRepository.find(id);
     List<User> assignees = issueCreateRequest.getAssigneeUserIdList()
         .stream()
         .map(userRepository::findByUserId)
         .collect(toList());
     List<Label> labels = issueCreateRequest.getLabelIdList()
         .stream()
-        .map(id -> labelRepository.find(id).orElseThrow(LabelNotFoundException::new))
+        .map(labelId -> labelRepository.find(labelId).orElseThrow(LabelNotFoundException::new))
         .collect(toList());
 
     Issue newIssue = Issue.builder()
@@ -127,10 +127,10 @@ public class IssueService {
     return issueNumber.equals(savedIssueNumber);
   }
 
-  public boolean createComment(Long issueNumber, CommentRequest commentRequest) {
+  public boolean createComment(Long issueNumber, CommentRequest commentRequest, Long id) {
     Issue issue = issueRepository.find(issueNumber);
     LocalDateTime now = LocalDateTime.now();
-    User writer = userRepository.find(1L); // TODO: 유저정보 토큰에서 파싱해오기
+    User writer = userRepository.find(id);
 
     Comment comment = new Comment(commentRequest, issue, now, writer);
     log.debug("저장 전 코멘트 정보: {}", comment);

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/LoginService.java
@@ -43,7 +43,14 @@ public class LoginService {
     User user = authService.getUserInfoToToken(token);
     log.debug("User Info : {}", user);
 
-    Long id = userRepository.save(user);
+    User existedUser = userRepository.findByUserId(user.getUserId());
+    Long id;
+    if (existedUser != null) {
+      existedUser.changeGithubToken(user.getGithubToken());
+      id = userRepository.save(existedUser);
+    } else {
+      id = userRepository.save(user);
+    }
     user = userRepository.find(id);
     log.debug("저장 후 유저 정보: {}", user);
 


### PR DESCRIPTION
Fixes #96

## 설명

- [x] 로그인 인터셉터 추가
- [x] JWT 만료시 쿠키 만료
- [x] 하드코딩으로 유저를 넣지 않도록 변경
- [x] 유저정보 중복저장되는 부분 변경

## 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [x] 관련 문서 업데이트 필요

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
