### PR TITLE
[BE-#103] refactor: 하드코딩된 redirect url 정보 시스템 환경변수로 설정

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -66,7 +66,7 @@ dependencies {
             'io.jsonwebtoken:jjwt-jackson:0.11.1' // or 'io.jsonwebtoken:jjwt-gson:0.11.1' for gson
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    implementation 'com.h2database:h2'
+    testImplementation 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/LoginService.java
@@ -18,7 +18,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Service
 public class LoginService {
 
-  public static final URI ROOT_URL = URI.create("http://localhost:52330");
+  private static final URI ROOT_URL = URI.create(System.getenv("ROOT_URL"));
   private static final int MAX_AGE = 7 * 24 * 60 * 60;
   private static final String AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 

--- a/BE/src/test/java/kr/codesquad/issuetracker/domain/user/UserDTOTest.java
+++ b/BE/src/test/java/kr/codesquad/issuetracker/domain/user/UserDTOTest.java
@@ -13,7 +13,7 @@ class UserDTOTest {
   @DisplayName("toString method test")
   void toStringMethodTest() {
     String str = UserDTO.of("1", "test", "test", "test@email.com").toString();
-    assertThat(str).isEqualTo("UserDTO(nickname=test, email=test@email.com)");
+    assertThat(str).isEqualTo("UserDTO(id=1, userId=test, nickname=test, email=test@email.com)");
   }
 
   @Test
@@ -29,7 +29,8 @@ class UserDTOTest {
     userMap.put("nickname", nickname);
     userMap.put("email", email);
 
-    User user = User.builder().nickname(nickname).email(email).build();
+    User user = User.builder().id(Long.parseLong(id)).userId(userId).nickname(nickname).email(email)
+        .build();
 
     // then
     UserDTO actual1 = UserDTO.of(id, userId, nickname, email);


### PR DESCRIPTION
Fixes #103

## 설명

하드코딩된 redirect url 정보를 시스템 환경변수에 설정합니다.
처음에 properties로 저장하려고 했는데, 읽히지가 않아서 어차피 변경가능성이 없으므로 시스템 환경변수로 지정하였습니다.
h2 db가 읽히는 문제가 있어, test에서만 사용하도록 변경합니다.
동작하지 않는 일부 테스트 코드를 수정합니다.

## 작업 유형

- [x] 신규 기능 추가

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
