### PR TITLE
[BE-#112] Issue 생성 테스트 코드 추가 및 REST Docs 추가

### DIFF
--- a/BE/src/docs/asciidoc/api-docs.adoc
+++ b/BE/src/docs/asciidoc/api-docs.adoc
@@ -70,6 +70,24 @@ include::{snippets}/issue-controller-test/이슈_상세정보_보기_테스트/h
 
 include::{snippets}/issue-controller-test/이슈_상세정보_보기_테스트/response-fields.adoc[]
 
+=== POST 이슈 생성
+
+==== CURL
+
+include::{snippets}/issue-controller-test/이슈_생성_테스트/curl-request.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/issue-controller-test/이슈_생성_테스트/http-request.adoc[]
+
+==== HTTP Request Fields
+
+include::{snippets}/issue-controller-test/이슈_생성_테스트/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/issue-controller-test/이슈_생성_테스트/http-response.adoc[]
+
 == Login 관련 API
 
 === GET JWT 없이 로그인 하는 경우

--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
@@ -22,6 +22,8 @@ import kr.codesquad.issuetracker.service.MilestoneService;
 import kr.codesquad.issuetracker.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,13 +65,14 @@ public class IssueController {
   }
 
   @PostMapping("")
-  public JobResponse createIssue(@RequestBody IssueCreateRequest issueCreateRequest,
+  public ResponseEntity<JobResponse> createIssue(@RequestBody IssueCreateRequest issueCreateRequest,
       HttpServletRequest request
   ) {
     log.debug("요청 객체: {}", issueCreateRequest);
     Long id = Long.parseLong(((UserDTO) request.getAttribute("user")).getId());
 
-    return JobResponse.of(issueService.createIssue(issueCreateRequest, id));
+    return new ResponseEntity<>(JobResponse.of(issueService.createIssue(issueCreateRequest, id)),
+        HttpStatus.CREATED);
   }
 
   @PutMapping("{issueNumber}")

--- a/BE/src/test/java/kr/codesquad/issuetracker/controller/IssueControllerTest.java
+++ b/BE/src/test/java/kr/codesquad/issuetracker/controller/IssueControllerTest.java
@@ -11,7 +11,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -354,7 +354,7 @@ class IssueControllerTest {
         .andExpect(jsonPath("$.opened", is(issue.isOpened())))
         .andDo(document("{class-name}/{method-name}",
             preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()),
-            relaxedResponseFields(
+            responseFields(
                 fieldWithPath("issueNumber").description("이슈의 번호(고유한 값)")
                     .type(JsonFieldType.NUMBER),
                 fieldWithPath("title").description("이슈의 제목").type(JsonFieldType.STRING),
@@ -422,6 +422,19 @@ class IssueControllerTest {
         .andDo(print())
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.success", is(true)))
-        .andExpect(jsonPath("$.message", is("성공")));
+        .andExpect(jsonPath("$.message", is("성공")))
+        .andDo(document("{class-name}/{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("title").description("이슈의 제목").type(JsonFieldType.STRING),
+                fieldWithPath("comment").description("이슈의 설명이자 첫번째 코멘트").type(JsonFieldType.STRING),
+                fieldWithPath("assigneeUserIdList").optional().description("담당자의 UserId 목록")
+                    .type(JsonFieldType.ARRAY),
+                fieldWithPath("labelIdList").optional().description("이슈에 할당할 라벨의 Id 목록")
+                    .type(JsonFieldType.ARRAY),
+                fieldWithPath("milestoneId").optional().description("이슈에 할당할 마일스톤의 Id")
+                    .type(JsonFieldType.NUMBER)
+            )));
   }
 }

--- a/BE/src/test/java/kr/codesquad/issuetracker/controller/IssueControllerTest.java
+++ b/BE/src/test/java/kr/codesquad/issuetracker/controller/IssueControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.Cookie;
+import kr.codesquad.issuetracker.controller.request.IssueCreateRequest;
 import kr.codesquad.issuetracker.controller.request.IssuesOpenStatusChangeRequest;
 import kr.codesquad.issuetracker.controller.response.IssueDetail;
 import kr.codesquad.issuetracker.domain.comment.CommentOfIssue;
@@ -396,5 +398,30 @@ class IssueControllerTest {
                     .type(JsonFieldType.STRING),
                 fieldWithPath("opened").description("이슈 오픈 여부").type(JsonFieldType.BOOLEAN)
             )));
+  }
+
+  @Test
+  @DisplayName("이슈 생성 테스트")
+  void 이슈_생성_테스트() throws Exception {
+    // given
+    IssueCreateRequest request = new IssueCreateRequest();
+    request.setTitle("이슈 제목");
+    request.setMilestoneId(1L);
+    request.setComment("이슈 코멘트");
+    request.setLabelIdList(Arrays.asList(1L, 2L));
+    request.setAssigneeUserIdList(Arrays.asList("test"));
+
+    when(issueService.createIssue(any(IssueCreateRequest.class), any(Long.class)))
+        .thenReturn(true);
+
+    // then
+    MockHttpServletRequestBuilder requestBuilder = post("/issues")
+        .contentType(MediaType.APPLICATION_JSON)
+        .cookie(new Cookie("jwt", this.jwt)).content(asJsonString(request));
+    mockMvc.perform(requestBuilder)
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success", is(true)))
+        .andExpect(jsonPath("$.message", is("성공")));
   }
 }


### PR DESCRIPTION
## 설명

Issue 생성 Controller의 테스트 코드를 추가합니다.
Issue 생성 Controller의 REST Docs를 추가합니다.
Issue 생성 Controller의 응답코드를 201로 변경합니다.

## 작업 유형

- [x] 신규 기능 추가
- [x] 관련 문서 업데이트 필요

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
