### PR TITLE
[BE-#112] REST Docs 커스텀 Snippet 적용 및 label 삭제 API 테스트 코드 및 API 문서 추가

### DIFF
--- a/BE/src/docs/asciidoc/api-docs.adoc
+++ b/BE/src/docs/asciidoc/api-docs.adoc
@@ -186,6 +186,10 @@ include::{snippets}/label-controller-test/label_수정_테스트/curl-request.ad
 
 include::{snippets}/label-controller-test/label_수정_테스트/http-request.adoc[]
 
+==== HTTP Path Parameters
+
+include::{snippets}/label-controller-test/label_수정_테스트/path-parameters.adoc[]
+
 ==== HTTP Request Fields
 
 include::{snippets}/label-controller-test/label_수정_테스트/request-fields.adoc[]
@@ -197,3 +201,21 @@ include::{snippets}/label-controller-test/label_수정_테스트/http-response.a
 ==== HTTP Response Fields
 
 include::{snippets}/label-controller-test/label_수정_테스트/response-fields.adoc[]
+
+=== DELETE 라벨 삭제
+
+==== CURL
+
+include::{snippets}/label-controller-test/label_삭제_테스트/curl-request.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/label-controller-test/label_삭제_테스트/http-request.adoc[]
+
+==== HTTP Path Parameters
+
+include::{snippets}/label-controller-test/label_삭제_테스트/path-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/label-controller-test/label_삭제_테스트/http-response.adoc[]

--- a/BE/src/test/java/kr/codesquad/issuetracker/controller/LabelControllerTest.java
+++ b/BE/src/test/java/kr/codesquad/issuetracker/controller/LabelControllerTest.java
@@ -6,6 +6,10 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -13,10 +17,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -170,7 +172,7 @@ class LabelControllerTest {
   @DisplayName("Label 수정 테스트")
   void label_수정_테스트() throws Exception {
     // given
-    Long labelId = 1L;
+    long labelId = 1L;
     LabelRequest labelRequest = new LabelRequest();
     labelRequest.setTitle("수정할 타이틀");
     labelRequest.setColor("#AAAAAA");
@@ -179,7 +181,7 @@ class LabelControllerTest {
     when(labelService.updateLabel(any(Long.class), any(LabelRequest.class))).thenReturn(true);
 
     // then
-    MockHttpServletRequestBuilder requestBuilder = put("/labels/" + labelId.intValue())
+    MockHttpServletRequestBuilder requestBuilder = put("/labels/{id}", labelId)
         .contentType(MediaType.APPLICATION_JSON)
         .characterEncoding("UTF-8")
         .content(asJsonString(labelRequest))
@@ -192,6 +194,9 @@ class LabelControllerTest {
         .andDo(document("{class-name}/{method-name}",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("id").description("라벨의 id")
+            ),
             requestFields(
                 fieldWithPath("title").description("Label의 타이틀"),
                 fieldWithPath("color").description("Label의 배경 컬러(Hex code)"),
@@ -200,6 +205,29 @@ class LabelControllerTest {
             responseFields(
                 fieldWithPath("success").description("성공 여부").type(JsonFieldType.BOOLEAN),
                 fieldWithPath("message").description("정보성 메시지").type(JsonFieldType.STRING)
+            )));
+  }
+
+  @Test
+  @DisplayName("Label 삭제 테스트")
+  void label_삭제_테스트() throws Exception {
+    // given
+    Long labelId = 1L;
+
+    // then
+    MockHttpServletRequestBuilder requestBuilder = delete("/labels/{id}", labelId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .cookie(this.cookie);
+    mockMvc.perform(requestBuilder)
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success", is(true)))
+        .andExpect(jsonPath("$.message", is("성공")))
+        .andDo(document("{class-name}/{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("id").description("라벨의 id")
             )));
   }
 }

--- a/BE/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/BE/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,11 @@
+|===
+  |Parameter|Description|필수값
+
+{{#parameters}}
+  |{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+  |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+  |{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+
+{{/parameters}}
+
+  |===

--- a/BE/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/BE/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,12 @@
+|===
+  |Path|Type|필수값|Description
+
+{{#fields}}
+  |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+  |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+  |{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+  |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+  |===


### PR DESCRIPTION
## 설명

REST Docs 커스텀 스니펫을 적용합니다.
참고(https://github.com/spring-projects/spring-restdocs/tree/master/spring-restdocs-core/src/main/resources/org/springframework/restdocs/templates/asciidoctor)

label 삭제 API 테스트 코드 및 문서를 추가합니다.

## 작업 유형

- [x] 신규 기능 추가
- [x] 관련 문서 업데이트 필요

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
