### PR TITLE
[FE] 이슈 생성, 이슈 상세 페이지 라우팅 구현

### DIFF
--- a/FE/public/index.html
+++ b/FE/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <base href="/" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Issue Tracker</title>

--- a/FE/src/views/components/Router.js
+++ b/FE/src/views/components/Router.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import IssueListPage from "Pages/IssueListPage";
+import CreateIssuePage from "Pages/CreateIssuePage";
+import IssueDetailPage from "Pages/IssueDetailPage";
 import LabelListPage from "Pages/LabelListPage";
 
 const LoginPage = () => <div>LoginPage</div>;
-const IssueDetailPage = () => <div>IssueDetailPage</div>;
-const CreateIssuePage = () => <div>CreateIssuePage</div>;
 const MilestoneListPage = () => <div>MilestoneListPage</div>;
 const CreateMilestonePage = () => <div>CreateMilestonePage</div>;
 const EditMilestonePage = () => <div>EditMilestonePage</div>;
@@ -15,9 +15,9 @@ export default () => (
   <BrowserRouter>
     <Switch>
       <Route path="/" exact component={LoginPage} />
-      <Route path="/issues" component={IssueListPage} />
+      <Route path="/issues" exact component={IssueListPage} />
+      <Route path="/issues/new" exact component={CreateIssuePage} />
       <Route path="/issues/:id" component={IssueDetailPage} />
-      <Route path="/issues/new" component={CreateIssuePage} />
       <Route path="/milestones" component={MilestoneListPage} />
       <Route path="/milestones/new " component={CreateMilestonePage} />
       <Route path="/milestones/:id/edit" component={EditMilestonePage} />

--- a/FE/src/views/components/issues/IssueItem.jsx
+++ b/FE/src/views/components/issues/IssueItem.jsx
@@ -6,11 +6,13 @@ import Label from "@/common/Label";
 import { getRelativeTime } from "Utils/utilFunctions";
 
 const IssueItem = (props) => {
-  const { issueNumber, title, createdAt, author, assignees, labels, milestone } = props;
+  const { issueNumber, title, createdAt, author, assignees, labels, milestone, opened } = props;
   return (
     <StyledIssueItem>
       <Checkbox />
-      <ExclamationCircleOutlined style={{ marginLeft: "10px" }} />
+      <ExclamationCircleOutlined
+        style={{ marginLeft: "10px", color: opened ? "#2EA44F" : "#D73A4A" }}
+      />
       <ContentsWrapper>
         <TitleWrapper>
           <Title>{title}</Title>
@@ -55,6 +57,7 @@ const StyledIssueItem = styled.div`
 const ContentsWrapper = styled.div`
   margin-left: 8px;
   margin-right: auto;
+  color: #898989;
 `;
 
 const TitleWrapper = styled.div`
@@ -76,7 +79,6 @@ const LabelWrapper = styled.div`
 
 const Details = styled.span`
   font-size: 12px;
-  color: #898989;
 `;
 
 const AssigneesWrapper = styled.div`

--- a/FE/src/views/pages/IssueDetailPage.jsx
+++ b/FE/src/views/pages/IssueDetailPage.jsx
@@ -86,7 +86,7 @@ const CreateIssuePage = () => {
                 <SelectedItem>
                   {assignees.length > 0 &&
                     assignees.map(({ nickname, profileImage }) => (
-                      <User nickname={nickname} profileImage={profileImage} />
+                      <User key={nickname} nickname={nickname} profileImage={profileImage} />
                     ))}
                 </SelectedItem>
               </DropdownWrapper>
@@ -94,7 +94,9 @@ const CreateIssuePage = () => {
                 <CustomizedDropdown {...LabelData} />
                 <SelectedItem>
                   {labels.length > 0 &&
-                    labels.map(({ title, color }) => <Label title={title} color={color} />)}
+                    labels.map(({ title, color }) => (
+                      <Label key={title} title={title} color={color} />
+                    ))}
                 </SelectedItem>
               </DropdownWrapper>
               <DropdownWrapper>

--- a/FE/src/views/pages/IssueListPage.jsx
+++ b/FE/src/views/pages/IssueListPage.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link, useHistory } from "react-router-dom";
 import styled from "styled-components";
 import { Input, Checkbox } from "antd";
 import {
@@ -18,6 +19,8 @@ import CustomizedDropdown from "@/common/CustomizedDropdown";
 import { list } from "Assets/mockIssue";
 
 const IssueListPage = () => {
+  const history = useHistory();
+
   const onClickHandler = ({ key }) => {
     const [action, value] = key.split("_");
     console.log("action: ", action, "value: ", value);
@@ -78,7 +81,7 @@ const IssueListPage = () => {
                 { icon: <FlagOutlined />, title: "Milestones", param: "/milestones" },
               ]}
             />
-            <Button type="primary" text="New" />
+            <Button type="primary" text="New" onClick={() => history.push("/issues/new")} />
           </IssueListTab>
           <ResetQueriesWrapper>
             <a>
@@ -102,7 +105,9 @@ const IssueListPage = () => {
             </IssueListHeader>
             <IssueListBody>
               {list.map((item) => (
-                <IssueItem key={item.issueNumber} {...item} />
+                <Link to={`/issues/${item.issueNumber}`} key={item.issueNumber}>
+                  <IssueItem {...item} />
+                </Link>
               ))}
             </IssueListBody>
           </IssueListWrapper>


### PR DESCRIPTION
Resolve #152 

## 설명

이슈 목록 페이지(`/issues`)에서
New 버튼 클릭시 이슈 생성 페이지(`/issues/new`)로 이동
개별 이슈 클릭시 해당 이슈 상세 페이지(`/issues/:id`)로 이동

## 작업 유형

- [x] 신규 기능 추가
