### PR TITLE
[BE-#122] Milestone 목록 조회 테스트 코드 작성 및 REST Docs 추가

### DIFF
--- a/BE/src/docs/asciidoc/api-docs.adoc
+++ b/BE/src/docs/asciidoc/api-docs.adoc
@@ -225,3 +225,23 @@ include::{snippets}/label-controller-test/label_삭제_테스트/path-parameters
 ==== HTTP Response
 
 include::{snippets}/label-controller-test/label_삭제_테스트/http-response.adoc[]
+
+== Milestone 관련 API
+
+=== GET milestone List 검색조건에 해당하는 milestone 목록가져오기
+
+==== CURL
+
+include::{snippets}/milestone-controller-test/milestone_목록_조회_테스트/curl-request.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/milestone-controller-test/milestone_목록_조회_테스트/http-request.adoc[]
+
+==== HTTP RESPONSE
+
+include::{snippets}/milestone-controller-test/milestone_목록_조회_테스트/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/milestone-controller-test/milestone_목록_조회_테스트/response-fields.adoc[]

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/milestone/MilestoneOfMilestoneList.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/milestone/MilestoneOfMilestoneList.java
@@ -21,8 +21,8 @@ public class MilestoneOfMilestoneList {
   private String description;
   private LocalDate dueDate;
   private LocalDateTime lastUpdatedDate;
-  private long openIssueCount;
-  private long closedIssueCount;
+  private Long openIssueCount;
+  private Long closedIssueCount;
   private Integer completeRatio;
 
   @Builder
@@ -63,8 +63,8 @@ public class MilestoneOfMilestoneList {
 
   private void setIssueCountAndCompletePercentage(List<Issue> issues, int issueSize) {
     if (issueSize == 0) {
-      this.openIssueCount = 0;
-      this.closedIssueCount = 0;
+      this.openIssueCount = 0L;
+      this.closedIssueCount = 0L;
       this.completeRatio = null;
       return;
     }

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/milestone/MilestoneOfMilestoneList.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/milestone/MilestoneOfMilestoneList.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import kr.codesquad.issuetracker.domain.issue.Issue;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -22,7 +23,22 @@ public class MilestoneOfMilestoneList {
   private LocalDateTime lastUpdatedDate;
   private long openIssueCount;
   private long closedIssueCount;
-  private Integer complete;
+  private Integer completeRatio;
+
+  @Builder
+  private MilestoneOfMilestoneList(Long id, boolean isOpened, String title,
+      String description, LocalDate dueDate, LocalDateTime lastUpdatedDate, long openIssueCount,
+      long closedIssueCount, Integer completeRatio) {
+    this.id = id;
+    this.isOpened = isOpened;
+    this.title = title;
+    this.description = description;
+    this.dueDate = dueDate;
+    this.lastUpdatedDate = lastUpdatedDate;
+    this.openIssueCount = openIssueCount;
+    this.closedIssueCount = closedIssueCount;
+    this.completeRatio = completeRatio;
+  }
 
   public MilestoneOfMilestoneList(Milestone milestone) {
     this.id = milestone.getId();
@@ -49,11 +65,11 @@ public class MilestoneOfMilestoneList {
     if (issueSize == 0) {
       this.openIssueCount = 0;
       this.closedIssueCount = 0;
-      this.complete = null;
+      this.completeRatio = null;
       return;
     }
     this.openIssueCount = issues.stream().filter(Issue::isOpened).count();
     this.closedIssueCount = issueSize - this.openIssueCount;
-    this.complete = Math.toIntExact(closedIssueCount * 100 / issueSize);
+    this.completeRatio = Math.toIntExact(closedIssueCount * 100 / issueSize);
   }
 }

--- a/BE/src/test/java/kr/codesquad/issuetracker/controller/MilestoneControllerTest.java
+++ b/BE/src/test/java/kr/codesquad/issuetracker/controller/MilestoneControllerTest.java
@@ -1,0 +1,138 @@
+package kr.codesquad.issuetracker.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.Cookie;
+import kr.codesquad.issuetracker.domain.milestone.MilestoneOfMilestoneList;
+import kr.codesquad.issuetracker.domain.user.User;
+import kr.codesquad.issuetracker.domain.user.UserDTO;
+import kr.codesquad.issuetracker.service.JwtService;
+import kr.codesquad.issuetracker.service.MilestoneService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureRestDocs(uriHost = "13.124.148.192/api", uriPort = 80)
+@WebMvcTest(controllers = {MilestoneController.class})
+class MilestoneControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  MilestoneService milestoneService;
+
+  @MockBean
+  JwtService jwtService;
+
+  String jwt = "jwt";
+  UserDTO userDTO = UserDTO
+      .of(User.builder().id(1L).userId("jwtUser").email("jwt@idion.dev").nickname("jwt").build());
+  Cookie cookie = new Cookie("jwt", jwt);
+
+  public static String asJsonString(final Object obj) {
+    try {
+      return new ObjectMapper().writeValueAsString(obj);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    when(jwtService.getUserFromJws(jwt)).thenReturn(userDTO);
+  }
+
+  @Test
+  @DisplayName("Milestone 목록 조회 테스트")
+  void milestone_목록_조회_테스트() throws Exception {
+    // given
+    MilestoneOfMilestoneList milestoneDTO = MilestoneOfMilestoneList.builder()
+        .id(1L)
+        .title("Test")
+        .description("설명")
+        .isOpened(true)
+        .lastUpdatedDate(LocalDateTime.now())
+        .dueDate(LocalDate.now())
+        .openIssueCount(2L)
+        .closedIssueCount(2L)
+        .completeRatio(50)
+        .build();
+    List<MilestoneOfMilestoneList> milestoneList = Collections.singletonList(milestoneDTO);
+
+    when(milestoneService.findAll()).thenReturn(milestoneList);
+
+    // then
+    mockMvc.perform(get("/milestones").contentType(MediaType.APPLICATION_JSON).cookie(cookie))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.milestones", hasSize(milestoneList.size())))
+        .andExpect(jsonPath("$.milestones[0].id").value(Matchers.anyOf(
+            Matchers.equalTo((Number) milestoneList.get(0).getId()),
+            Matchers.equalTo(milestoneList.get(0).getId().intValue())
+        )))
+        .andExpect(jsonPath("$.milestones[0].title", is(milestoneList.get(0).getTitle())))
+        .andExpect(
+            jsonPath("$.milestones[0].description", is(milestoneList.get(0).getDescription())))
+        .andExpect(jsonPath("$.milestones[0].opened", is(milestoneList.get(0).isOpened())))
+        .andExpect(jsonPath("$.milestones[0].openIssueCount").value(Matchers.anyOf(
+            Matchers.equalTo((Number) milestoneList.get(0).getOpenIssueCount()),
+            Matchers.equalTo(milestoneList.get(0).getOpenIssueCount().intValue())
+        )))
+        .andExpect(jsonPath("$.milestones[0].closedIssueCount").value(Matchers.anyOf(
+            Matchers.equalTo((Number) milestoneList.get(0).getClosedIssueCount()),
+            Matchers.equalTo(milestoneList.get(0).getClosedIssueCount().intValue())
+        )))
+        .andExpect(
+            jsonPath("$.milestones[0].completeRatio", is(milestoneList.get(0).getCompleteRatio())))
+        .andDo(document("{class-name}/{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            responseFields(
+                fieldWithPath("milestones").description("마일스톤의 목록").type(JsonFieldType.ARRAY),
+                fieldWithPath("milestones[].id").description("마일스톤의 고유 id")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("milestones[].title").description("마일스톤의 타이틀")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("milestones[].description").description("마일스톤에 대한 설명")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("milestones[].dueDate").description("마일스톤의 데드라인")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("milestones[].lastUpdatedDate").description("마일스톤의 최종 수정 일자")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("milestones[].openIssueCount").description("마일스톤의 열려있는 issue 개수")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("milestones[].closedIssueCount").description("마일스톤의 닫힌 issue 개수")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("milestones[].completeRatio").description("마일스톤의 완료율(%)")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("milestones[].opened").description("마일스톤의 Open 여부")
+                    .type(JsonFieldType.BOOLEAN)
+            )));
+  }
+}


### PR DESCRIPTION
## 설명

Milestone 목록 조회 테스트 코드를 작성하고 REST Docs를 추가합니다.
MilestoneOfMilestoneList 클래스의 complete 필드를 좀 더 명확한 이름으로 변경합니다.
MilestoneOfMilestoneList에 빌더 패턴을 추가합니다.

## 작업 유형

- [x] 신규 기능 추가
- [x] 관련 문서 업데이트 필요

## 체크리스트

- [x] 이 PR의 코드들이 이 프로젝트의 스타일 가이드를 준수했는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 새로운 경고를 만들어내지 않았는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
